### PR TITLE
Update to zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "zig-gpio",
+    .name = .zig-gpio,
     .version = "0.0.1",
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .zig-gpio,
+    .name = .ziggpio,
     .version = "0.0.1",
     .paths = .{""},
 }


### PR DESCRIPTION
I can't remember if the removal of the `-` in the name was because of the naming convention not allowing it or what